### PR TITLE
Add EDA notebook: 데이터 로딩, 정제, 기초 분석

### DIFF
--- a/notebooks/football_transfer_analysis.ipynb
+++ b/notebooks/football_transfer_analysis.ipynb
@@ -1,9 +1,274 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# 1. Imort Data"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0",
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "players_path = '../data/players.csv'\n",
+    "players_valuations_path = '../data/player_valuations.csv'\n",
+    "\n",
+    "players = pd.read_csv(players_path)\n",
+    "players_valuations = pd.read_csv(players_valuations_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "# 2. Dataset Information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## 2-1. players"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(players.info())\n",
+    "display(players.head())\n",
+    "print(players.columns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## 2-3. players_valuations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(players_valuations.info())\n",
+    "display(players_valuations.head())\n",
+    "print(players_valuations.columns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "## 결측치 확인"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(players.isna().sum(),'\\n')\n",
+    "print(players_valuations.isna().sum())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "## 기초 통계량"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 특정 컬럼에 대해 unique 값 개수 출력 함수 정의\n",
+    "def count_value(df, column):\n",
+    "    count = len(df[column].unique())\n",
+    "    print(f'Total {column}: {count}')\n",
+    "\n",
+    "columns = ['player_id', 'current_club_id', 'country_of_citizenship'] # player_id, 소속 구단, 국적에 대한 unique 개수 확인\n",
+    "\n",
+    "for column in columns:\n",
+    "    count_value(players, column)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 선수 시장가치(market_value_in_eur)의 기초 통계량\n",
+    "players_valuations['market_value_in_eur'].describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.options.display.float_format = '{:.0f}'.format\n",
+    "players_valuations['market_value_in_eur'].describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 평균 시장가치 이상인 선수 비율 계산\n",
+    "mean_ = players_valuations['market_value_in_eur'].mean()\n",
+    "over_mean = len(players_valuations[players_valuations['market_value_in_eur'] > mean_])\n",
+    "total = len(players_valuations)\n",
+    "print(f\"percentile of player over mean value: {over_mean/total*100:.2f}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "# 3. Handling DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "players_with_val = pd.merge(players, players_valuations, on='player_id')\n",
+    "players_with_val[players_with_val['last_name']=='Son'].tail()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "## 3-1. 태어난 년도 기준으로 각 연봉을 받았던 때의 나이 계산하여 age 컬럼 추가"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# \"YYYY-MM-DD” 형식의 date에서 연도만 뽑아내서 dateyear 컬럼 추가\n",
+    "players_with_val['dateyear'] = players_with_val['date'].apply(lambda x: int(x[:4]))\n",
+    "players_with_val['age'] = players_with_val['dateyear'] - players_with_val['date_of_birth'].apply(lambda x: int(x[:4]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 선수별 동일 연도 데이터 중복 제거 → 가장 마지막 기록만 남김\n",
+    "players_with_val.drop_duplicates(['player_id','dateyear'], keep='last',inplace=True)\n",
+    "players_with_val[players_with_val['last_name']=='Son'].head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 분석에 필요한 컬럼만 선별\n",
+    "columns = [\n",
+    "    'player_id', 'current_club_id_y', 'first_name', 'last_name', 'name', 'last_season_x', 'country_of_citizenship', 'city_of_birth', 'position', 'sub_position', 'dateyear', 'age', 'market_value_in_eur_y']\n",
+    "players_with_val = players_with_val[columns]\n",
+    "\n",
+    "players_with_val.rename(\n",
+    "    columns={\n",
+    "    \"current_club_id_y\": \"current_club_id\",\n",
+    "    \"last_season_x\": \"last_season\",\n",
+    "    \"market_value_in_eur_y\":\"market_value_in_eur\"\n",
+    "    },\n",
+    "    inplace=True\n",
+    ")\n",
+    "\n",
+    "players_with_val"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "players_with_val['market_value_in_eur'].describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 2022년 기준 데이터만 추출\n",
+    "players_with_val_2022 = players_with_val[(players_with_val['dateyear'] == 2022) & (players_with_val['last_season'] == 2022)]\n",
+    "players_with_val_2022"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 2022년 선수별 market_value 순위 계산\n",
+    "players_with_val_2022['market_value_rank'] = players_with_val_2022['market_value_in_eur'].rank(method=\"min\", ascending=False)\n",
+    "\n",
+    "# market_value 기준 정렬 후 손흥민 선수 확인\n",
+    "players_with_val_2022.sort_values(by='market_value_rank')\n",
+    "players_with_val_2022[players_with_val_2022['last_name'] == 'Son']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
## 📊 작업 내용 (What)
- 데이터 로딩 및 전처리 (`players.csv`, `player_valuations.csv`)
- 결측치 처리 및 기초 통계량 확인
- 선수 ID, 클럽 ID, 국적별 유니크 값 개수 계산
- `players_with_val` 데이터프레임 생성 및 병합
- 연도(`dateyear`)와 나이(`age`) 계산 후 중복 제거

---

## 🛠️ 변경 사항 (Changes)
- `notebook.ipynb`에 EDA 코드 추가
- `data/` 디렉토리에 원본 CSV 파일 업로드
- 숫자형 변수(`market_value_in_eur`)에 대한 기술 통계량 확인
- 평균 초과 선수 비율 산출

---

## ✅ 확인 사항 (Checklist)
- [x] 데이터 경로 및 파일 정상 로딩 확인
- [x] 결측치 처리 후 이상치 없는지 검토
- [x] 연도 및 나이 계산 로직 정상 동작 확인
- [x] 코드 실행 시 오류 발생하지 않는지 확인

---

## 📌 참고 (Reference)
- 데이터 출처: [Transfermarkt](https://www.transfermarkt.com)
- 강의 자료: 제로베이스 파이썬 데이터 취업 스쿨