### PR TITLE
Add Visualization notebook: 데이터 시각화

### DIFF
--- a/notebooks/football_transfer_analysis.ipynb
+++ b/notebooks/football_transfer_analysis.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# 1. Imort Data"
+    "# 1. Import Data"
    ]
   },
   {
@@ -188,8 +188,10 @@
    "outputs": [],
    "source": [
     "# \"YYYY-MM-DD” 형식의 date에서 연도만 뽑아내서 dateyear 컬럼 추가\n",
-    "players_with_val['dateyear'] = players_with_val['date'].apply(lambda x: int(x[:4]))\n",
-    "players_with_val['age'] = players_with_val['dateyear'] - players_with_val['date_of_birth'].apply(lambda x: int(x[:4]))"
+    "players_with_val['dateyear'] = players_with_val['date'].apply(lambda x: int(str(x)[:4]) if pd.notna(x) else None)\n",
+    "players_with_val['age'] = players_with_val['dateyear'] - players_with_val['date_of_birth'].apply(\n",
+    "    lambda x: int(str(x)[:4]) if pd.notna(x) else None\n",
+    ")"
    ]
   },
   {
@@ -266,9 +268,962 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "23",
+   "metadata": {},
+   "source": [
+    "# 4. Visaulization"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib as mpl\n",
+    "\n",
+    "# 한글 폰트 설정\n",
+    "mpl.rc('font', family='AppleGothic')\n",
+    "# 음수 기호 깨짐 방지\n",
+    "mpl.rcParams['axes.unicode_minus'] = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25",
+   "metadata": {},
+   "source": [
+    "## 4-1. 연도별 선수가치 분포도"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "\n",
+    "plt.figure(figsize=(8,6))\n",
+    "plt.boxplot(players_with_val['market_value_in_eur'])\n",
+    "plt.title('선수들의 시장가치 분포도')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27",
+   "metadata": {},
+   "source": [
+    "대부분의 선수들의 시장가치는 낮은 구간에 몰려있고\n",
+    "극소수의 스타 선수들만 박스플롯의 이상치로 표시되어있음을 볼 수 있다"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 선수 가치별로 그룹화하여 같은 시장가치를 가진 선수 수를 카운트\n",
+    "plt.figure(figsize=(8,6))\n",
+    "players_with_val.groupby('market_value_in_eur')['player_id'].count().plot()\n",
+    "plt.title('가치별 선수 수 분포도')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29",
+   "metadata": {},
+   "source": [
+    "* x축: market_value_in_eur (시장가치, 보통 유로 단위).\n",
+    "*  같은 시장가치를 가진 선수 수.\n",
+    "결과적으로 “특정 시장가치를 가진 선수가 몇 명 있는지”를 보여줌.\n",
+    "\n",
+    "**문제점**\n",
+    "* 시장가치 데이터는 연속형(금액이 다양함)인데, 그대로 groupby 하면 x축에 값이 너무 많아 복잡하게 나옴.\n",
+    "* 예: 시장가치가 500,000 유로, 510,000 유로, 520,000 유로… 이런 값들이 전부 개별 x축으로 들어감 → 해석 어려움."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sum_per_year = players_with_val.groupby('dateyear')['market_value_in_eur'].sum()\n",
+    "x = sum_per_year.index\n",
+    "y = sum_per_year.values\n",
+    "\n",
+    "plt.figure(figsize=(8,6))\n",
+    "plt.plot(x, y)\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.title('연도별 전체 선수 시장가치 총합의 변화 추세')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "max_per_year = players_with_val.groupby('dateyear')['market_value_in_eur'].max()\n",
+    "x = max_per_year.index\n",
+    "y = max_per_year.values\n",
+    "\n",
+    "plt.figure(figsize=(8,6))\n",
+    "plt.plot(x,y)\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.title('연도별 선수가치 max 값의 변화 추세')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean_per_year = players_with_val.groupby('dateyear')['market_value_in_eur'].mean()\n",
+    "x = mean_per_year.index\n",
+    "y = mean_per_year.values\n",
+    "\n",
+    "plt.figure(figsize=(8,6))\n",
+    "plt.plot(x, y)\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.title('연도별 선수가치 평균값의 변화 추세')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y = players_with_val.groupby('dateyear')['player_id'].count()\n",
+    "\n",
+    "plt.figure(figsize=(8,6))\n",
+    "plt.bar(x, y)\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.title('연도별 선수가치별 선수 수의 변화 추세')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "colors = ['blue' if count > 5000 else 'green' for count in y]\n",
+    "\n",
+    "plt.figure(figsize=(8,6))\n",
+    "plt.bar(x, y, color=colors)\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.title(\"연도별 선수 시장가치 총합\")\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "players_with_val = players_with_val[(players_with_val['dateyear'] >= 2013) & (players_with_val['dateyear'] < 2023)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "years = sorted(players_with_val['dateyear'].unique())\n",
+    "\n",
+    "num_plots = len(years)\n",
+    "num_rows = 4\n",
+    "num_cols = (num_plots + 3) // 4\n",
+    "\n",
+    "fig, axes = plt.subplots(num_rows, num_cols, figsize=(12, 8))\n",
+    "\n",
+    "axes = axes.flatten()\n",
+    "\n",
+    "for i, year in enumerate(years):\n",
+    "    market_values = players_with_val[players_with_val['dateyear'] == year]['market_value_in_eur'].values\n",
+    "\n",
+    "    ax = axes[i]\n",
+    "    ax.boxplot(market_values)\n",
+    "    ax.set_title(year)\n",
+    "\n",
+    "for j in range(num_plots, num_rows * num_cols):\n",
+    "    fig.delaxes(axes[j])\n",
+    "\n",
+    "fig.suptitle(\"연도별 선수 시장가치 분포\", fontsize=16)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37",
+   "metadata": {},
+   "source": [
+    "## 4-2. 나이별 시장가치 분포도"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "players_with_val.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "age_market_values = players_with_val.groupby('age')['market_value_in_eur'].mean()\n",
+    "\n",
+    "plt.figure(figsize=(8,6))\n",
+    "age_market_values.plot(kind='bar')\n",
+    "plt.xlabel('Age')\n",
+    "plt.ylabel('Mean Market Value (EUR)')\n",
+    "plt.xticks(rotation=0)\n",
+    "plt.title('나이별 평균가치 분포도')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filtered_data = players_with_val[players_with_val['age'] <= 35]\n",
+    "\n",
+    "age_market_values = filtered_data.groupby('age')['market_value_in_eur'].mean()\n",
+    "\n",
+    "sorted_values = age_market_values.sort_values(ascending=False)\n",
+    "\n",
+    "top_5_intervals = sorted_values.head(5).index\n",
+    "\n",
+    "colors = ['blue' if age in top_5_intervals else 'green' for age in age_market_values.index]\n",
+    "\n",
+    "plt.figure(figsize=(8, 6))\n",
+    "age_market_values.plot(kind='bar', color=colors)\n",
+    "plt.xlabel('Age')\n",
+    "plt.ylabel('Mean Market Value (EUR)')\n",
+    "plt.title('나이별 평균가치 분포(~35 세) 중 top 5 ')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "def get_top_name(g):\n",
+    "    if g['market_value_in_eur'].notna().any():\n",
+    "        return g.loc[g['market_value_in_eur'].idxmax(), 'name']\n",
+    "    return np.nan\n",
+    "\n",
+    "top_players = (\n",
+    "    filtered_data\n",
+    "    .groupby('age', group_keys=False)\n",
+    "    .apply(get_top_name)\n",
+    ")\n",
+    "\n",
+    "\n",
+    "plt.figure(figsize=(12, 6))\n",
+    "ax = age_market_values.plot(kind='bar', color=colors)\n",
+    "ax.set_xlabel('Age')\n",
+    "ax.set_ylabel('Mean Market Value (EUR)')\n",
+    "ax.set_title('나이별 최고가 선수 (Up to 35)')\n",
+    "\n",
+    "for i, (age, value) in enumerate(zip(age_market_values.index, age_market_values.values)):\n",
+    "    name = top_players.get(age, None)\n",
+    "    if pd.notna(name):\n",
+    "        ax.text(i, value * 1.01, name,\n",
+    "                ha='center', va='bottom',\n",
+    "                fontsize=9,\n",
+    "                fontweight='bold' if age in sorted_values.head().index else 'normal',\n",
+    "                rotation=0)\n",
+    "\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42",
+   "metadata": {},
+   "source": [
+    "## 4-3. 포지셜별 가치 분포"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "position_market_values = players_with_val.groupby('position')['market_value_in_eur'].mean()\n",
+    "\n",
+    "plt.figure(figsize=(8,6))\n",
+    "position_market_values.plot(kind='bar')\n",
+    "plt.xlabel('Position')\n",
+    "plt.ylabel('Mean Market Value (EUR)')\n",
+    "plt.title('포지션별 평균 가치')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "position_market_values = players_with_val.groupby(['position', 'dateyear'])['market_value_in_eur'].mean()\n",
+    "\n",
+    "position_market_values = position_market_values.reset_index()\n",
+    "\n",
+    "plt.figure(figsize=(12, 8))\n",
+    "for position in position_market_values['position'].unique():\n",
+    "    position_data = position_market_values[position_market_values['position'] == position]\n",
+    "    plt.plot(position_data['dateyear'], position_data['market_value_in_eur'], label=position)\n",
+    "\n",
+    "plt.xlabel('Year')\n",
+    "plt.ylabel('Mean Market Value (EUR)')\n",
+    "plt.title('포지션별 평균 시장가치 추이 (연도별)')\n",
+    "plt.legend()\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "positions = players_with_val['position'].unique()\n",
+    "\n",
+    "fig, axes = plt.subplots(len(positions), figsize=(10, 20))\n",
+    "\n",
+    "for i, position in enumerate(positions):\n",
+    "    ax = axes[i]\n",
+    "    ax.set_title(position)\n",
+    "\n",
+    "    position_data = players_with_val[players_with_val['position'] == position]\n",
+    "    sub_positions = position_data['sub_position'].unique()\n",
+    "\n",
+    "    for sub_position in sub_positions:\n",
+    "        sub_position_data = position_data[position_data['sub_position'] == sub_position]\n",
+    "        sub_position_value = sub_position_data.groupby('dateyear')['market_value_in_eur'].mean()\n",
+    "\n",
+    "        ax.plot(sub_position_value.index, sub_position_value.values, label=sub_position)\n",
+    "\n",
+    "    ax.legend()\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "positions = players_with_val['position'].unique()\n",
+    "\n",
+    "fig, axes = plt.subplots(len(positions), figsize=(10, 20))\n",
+    "\n",
+    "for i, position in enumerate(positions):\n",
+    "    ax = axes[i]\n",
+    "    ax.set_title(position)\n",
+    "\n",
+    "    position_data = players_with_val[players_with_val['position'] == position]\n",
+    "    sub_positions = position_data['sub_position'].unique()\n",
+    "\n",
+    "    for sub_position in sub_positions:\n",
+    "        sub_position_data = position_data[position_data['sub_position'] == sub_position]\n",
+    "        sub_position_value = sub_position_data.groupby('dateyear')['market_value_in_eur'].mean()\n",
+    "\n",
+    "        ax.plot(sub_position_value.index, sub_position_value.values, label=sub_position)\n",
+    "\n",
+    "        top_players = sub_position_data.loc[sub_position_data.groupby('dateyear')['market_value_in_eur'].idxmax(), 'name']\n",
+    "\n",
+    "        for year, player in zip(sub_position_value.index, top_players):\n",
+    "            ax.text(year, sub_position_value[year], player, ha='center', va='bottom')\n",
+    "\n",
+    "    ax.legend()\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47",
+   "metadata": {},
+   "source": [
+    "## 4-4. 국가별 가치 분포"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "country_player_counts = players_with_val.drop_duplicates('player_id')['country_of_citizenship'].value_counts()\n",
+    "country_player_counts.sort_values(ascending=False)\n",
+    "\n",
+    "top_10_countries = country_player_counts.head(10)\n",
+    "\n",
+    "plt.figure(figsize=(12, 8))\n",
+    "top_10_countries.plot(kind='bar')\n",
+    "plt.xlabel('Country of Citizenship')\n",
+    "plt.ylabel('Number of Players')\n",
+    "plt.title('\tTop 10 국적별 선수 수 분포')\n",
+    "\n",
+    "for i, value in enumerate(top_10_countries):\n",
+    "    country = top_10_countries.index[i]\n",
+    "    plt.text(i, value, str(value), ha='center', va='bottom')\n",
+    "\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "country_player_counts_2022 = players_with_val_2022.drop_duplicates('player_id')['country_of_citizenship'].value_counts()\n",
+    "country_player_counts_2022.sort_values(ascending=False)\n",
+    "\n",
+    "top_10_countries = country_player_counts_2022.head(10)\n",
+    "\n",
+    "plt.figure(figsize=(12, 8))\n",
+    "top_10_countries.plot(kind='bar')\n",
+    "plt.xlabel('Country of Citizenship')\n",
+    "plt.ylabel('Number of Players')\n",
+    "plt.title('\tTop 10 국적별 선수 수 분포 - 2022')\n",
+    "\n",
+    "for i, value in enumerate(top_10_countries):\n",
+    "    country = top_10_countries.index[i]\n",
+    "    plt.text(i, value, str(value), ha='center', va='bottom')\n",
+    "\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50",
+   "metadata": {},
+   "source": [
+    "## 4-5. 국가별 선수 수 분포도"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geopy.geocoders import Nominatim\n",
+    "import time\n",
+    "\n",
+    "locations = []\n",
+    "\n",
+    "errors = []\n",
+    "\n",
+    "geolocator = Nominatim(user_agent=\"my-app\")\n",
+    "\n",
+    "countries = country_player_counts.index\n",
+    "\n",
+    "for country in countries:\n",
+    "    try:\n",
+    "        location = geolocator.geocode(country)\n",
+    "    except Exception as e:\n",
+    "        print(f\"지오코딩 오류 - 나라: {country}. 오류: {e}\")\n",
+    "        errors.append(country)\n",
+    "        continue\n",
+    "\n",
+    "    time.sleep(0.3)\n",
+    "    latitude = location.latitude\n",
+    "    longitude = location.longitude\n",
+    "\n",
+    "    locations.append((country, latitude, longitude))\n",
+    "    print(\"나라:\", country)\n",
+    "    print(\"위도:\", latitude)\n",
+    "    print(\"경도:\", longitude)\n",
+    "    print(\"-\"*20)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "locations_df_2022 = pd.DataFrame(locations)\n",
+    "locations_df_2022.rename(columns={\n",
+    "    0: 'country',\n",
+    "    1: 'Latitude',\n",
+    "    2: 'Longitude'\n",
+    "}, inplace=True)\n",
+    "\n",
+    "locations_df_2022['player_count'] = locations_df_2022.country.apply(lambda x: country_player_counts_2022.get(x, 0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plotly.express as px\n",
+    "\n",
+    "\n",
+    "fig = px.density_mapbox(\n",
+    "    locations_df_2022,\n",
+    "    lat=\"Latitude\",\n",
+    "    lon=\"Longitude\",\n",
+    "    z=\"player_count\",\n",
+    "    radius=15,\n",
+    "    center=dict(lat=20, lon=0),\n",
+    "    zoom=1,\n",
+    "    mapbox_style=\"open-street-map\"\n",
+    ")\n",
+    "\n",
+    "fig.update_layout(\n",
+    "    title=\"Density Map of 2022 Players\"\n",
+    ")\n",
+    "\n",
+    "fig.show(renderer=\"browser\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cities_in_england = players_with_val[players_with_val['country_of_citizenship'] == 'England'].drop_duplicates('player_id')['city_of_birth']\n",
+    "print(f\"Number of City in Enlgand: {len(cities_in_england.unique())}\")\n",
+    "\n",
+    "england_players_count = cities_in_england.value_counts()\n",
+    "\n",
+    "top_10_city_in_england = england_players_count.head(10)\n",
+    "\n",
+    "plt.figure(figsize=(12, 8))\n",
+    "top_10_city_in_england.plot(kind='bar')\n",
+    "plt.xlabel('City of England')\n",
+    "plt.ylabel('Number of Playesr')\n",
+    "plt.title('영국 도시별 선수 수 분포')\n",
+    "\n",
+    "for i, value in enumerate(top_10_city_in_england):\n",
+    "    city = top_10_city_in_england.index[i]\n",
+    "    plt.text(i, value, str(value), ha='center', va='bottom')\n",
+    "\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "top_50_city_in_england = england_players_count.head(50)\n",
+    "\n",
+    "enlgand_city_locations = []\n",
+    "\n",
+    "errors = []\n",
+    "\n",
+    "geolocator = Nominatim(user_agent=\"my-app\")\n",
+    "\n",
+    "cities = top_50_city_in_england.index\n",
+    "\n",
+    "for city in cities:\n",
+    "    try:\n",
+    "        location = geolocator.geocode(city)\n",
+    "    except Exception as e:\n",
+    "        print(f\"지오코딩 오류 - 나라: {city}. 오류: {e}\")\n",
+    "        errors.append(city)\n",
+    "        continue\n",
+    "\n",
+    "    time.sleep(0.3)\n",
+    "    latitude = location.latitude\n",
+    "    longitude = location.longitude\n",
+    "\n",
+    "    enlgand_city_locations.append((city, latitude, longitude))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "england_locations_df = pd.DataFrame(enlgand_city_locations)\n",
+    "england_locations_df.rename(columns={\n",
+    "    0: 'city',\n",
+    "    1: 'Latitude',\n",
+    "    2: 'Longitude'\n",
+    "}, inplace=True)\n",
+    "\n",
+    "england_locations_df['player_count'] = england_locations_df.city.apply(lambda x: england_players_count[x])\n",
+    "england_locations_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import folium\n",
+    "\n",
+    "england_location = [55.8670, -4.2621]\n",
+    "england_map = folium.Map(location=england_location, zoom_start=5)\n",
+    "\n",
+    "for index, row in england_locations_df.iterrows():\n",
+    "    city = row['city']\n",
+    "    latitude = row['Latitude']\n",
+    "    longitude = row['Longitude']\n",
+    "    player_count = row['player_count']\n",
+    "\n",
+    "    radius = player_count / 5\n",
+    "    color = 'darkred' if player_count > 100 else 'red' if player_count > 50 else 'lightred'\n",
+    "    folium.CircleMarker(\n",
+    "        location=[latitude, longitude],\n",
+    "        radius=radius,\n",
+    "        color=color,\n",
+    "        fill=True,\n",
+    "        fill_color=color,\n",
+    "        fill_opacity=0.6,\n",
+    "        tooltip=f\"<b>{city}</b><br>Player Count: {player_count}\"\n",
+    "    ).add_to(england_map)\n",
+    "\n",
+    "england_map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_for_animation = pd.DataFrame(\n",
+    "    players_with_val[players_with_val['country_of_citizenship'] == 'England']\n",
+    "    .groupby(['dateyear', 'city_of_birth'])['player_id']\n",
+    "    .count()\n",
+    "    )\n",
+    "\n",
+    "df_for_animation.reset_index(inplace=True)\n",
+    "df_for_animation.rename(\n",
+    "    columns={\n",
+    "        'city_of_birth': 'city',\n",
+    "        'player_id': 'player_count'\n",
+    "        },\n",
+    "    inplace=True\n",
+    "    )\n",
+    "\n",
+    "df_for_animation = pd.merge(\n",
+    "    df_for_animation, england_locations_df[['city', 'Latitude', 'Longitude']],\n",
+    "    on='city', how='left')\n",
+    "\n",
+    "df_for_animation.dropna(inplace=True)\n",
+    "df_for_animation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plotly.express as px\n",
+    "\n",
+    "fig = px.scatter_geo(\n",
+    "    df_for_animation, lat=\"Latitude\", lon=\"Longitude\",\n",
+    "    color=\"player_count\", size=\"player_count\", hover_name=\"city\",\n",
+    "    animation_frame=\"dateyear\", projection=\"natural earth\"\n",
+    ")\n",
+    "\n",
+    "fig.update_geos(\n",
+    "    projection_scale=3.5,\n",
+    "    scope=\"europe\",\n",
+    "    center=dict(lat=55.8670, lon=-4.2621),\n",
+    ")\n",
+    "\n",
+    "fig.update_layout(\n",
+    "    title=\"England Football Player Count by City Over Years\",\n",
+    "    height=600, width=800,\n",
+    ")\n",
+    "\n",
+    "fig.show(renderer=\"browser\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60",
+   "metadata": {},
+   "source": [
+    "## 4-5. 클럽 단위 총 가치"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "clubs_path = '../data/clubs.csv'\n",
+    "competitions_path = '../data/competitions.csv'\n",
+    "\n",
+    "clubs = pd.read_csv(clubs_path)\n",
+    "competitions = pd.read_csv(competitions_path)\n",
+    "\n",
+    "print(clubs.head())\n",
+    "print(competitions.head())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clubs.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clubs_2022 = clubs[clubs['last_season'] == 2022]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "total_market_values = players_with_val_2022.groupby('current_club_id')['market_value_in_eur'].sum()\n",
+    "\n",
+    "clubs_2022['total_market_value'] = clubs_2022['club_id'].apply(lambda club_id: total_market_values[club_id])\n",
+    "clubs_2022"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "columns = ['competition_id', 'name', 'country_name']\n",
+    "competitions = competitions[columns].rename(columns={'competition_id': 'domestic_competition_id'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clubs_2022 = pd.merge(clubs_2022, competitions, on='domestic_competition_id')\n",
+    "\n",
+    "display(clubs_2022.head())\n",
+    "print(clubs_2022.info())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "columns = ['club_id', 'club_code', 'name_x', 'total_market_value', 'squad_size', 'average_age', 'foreigners_number', 'foreigners_percentage', 'name_y', 'country_name']\n",
+    "\n",
+    "clubs_2022 = clubs_2022[columns]\n",
+    "clubs_2022.rename(columns={\n",
+    "    \"name_x\": \"club_name\",\n",
+    "    \"name_y\": \"competition_name\"\n",
+    "}, inplace=True)\n",
+    "\n",
+    "clubs_2022"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clubs_2022"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd, plotly\n",
+    "print(pd.__version__, plotly.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plotly.express as px\n",
+    "\n",
+    "sorted_clubs_2022 = clubs_2022.sort_values('total_market_value', ascending=False)\n",
+    "\n",
+    "fig = px.treemap(\n",
+    "    sorted_clubs_2022,\n",
+    "    path=['club_name'],  # 'name'이 club_name임\n",
+    "    values='total_market_value',\n",
+    "    labels={'club_name': 'Club Name', 'total_market_value': 'Total Market Value'},\n",
+    "    title='Clubs in 2022 by Total Market Value'\n",
+    ")\n",
+    "fig.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sorted_clubs_2022 = clubs_2022.sort_values('total_market_value', ascending=False)\n",
+    "\n",
+    "fig = px.treemap(sorted_clubs_2022, path=['country_name', 'club_name'], values='total_market_value',\n",
+    "                 labels={'club_name': 'Club Name', 'total_market_value': 'Total Market Value'},\n",
+    "                 title='Clubs in 2022 by Total Market Value')\n",
+    "fig.show(renderer=\"browser\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = px.bar(sorted_clubs_2022, x='club_name', y='total_market_value', color='country_name',\n",
+    "             labels={'club_name': 'Club Name', 'total_market_value': 'Total Market Value'},\n",
+    "             title='Clubs in 2022 by Total Market Value')\n",
+    "fig.show(renderer=\"browser\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = px.box(clubs_2022, x='competition_name', y='total_market_value', color='competition_name',\n",
+    "             title='Market Value Distribution by Competition(Domestic League)',\n",
+    "             labels={'competition_name': 'Competition', 'total_market_value': 'Total Market Value'})\n",
+    "fig.show(renderer=\"browser\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = px.box(clubs_2022, x='competition_name', y='average_age', color='competition_name',\n",
+    "             title='Age Distribution by Competition(Domestic League)',\n",
+    "             labels={'competition_name': 'Competition', 'average_age': 'Average Age'})\n",
+    "fig.show(renderer=\"browser\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
## 📊 작업 내용 (What)
- 4-1. 연도별 시장가치 분포
- 4-2. 나이별 시장가치
- 4-3. 포지션/세부포지션
- 4-4. 국가별
- 4-5. 클럽 단위
---

## 🛠️ 변경 사항 (Changes)
- `notebook.ipynb`에 시각화 코드블록 추가
- Matplotlib 한글 폰트 설정(AppleGothic), 음수 기호 렌더링 고정
- 연도/나이 파생 컬럼 사용(dateyear, age)
- 지도/애니메이션 시각화를 위한 데이터 프레임 생성 로직 추가
- 클럽/대회 데이터(clubs.csv, competitions.csv) 로딩 및 전처리
- Plotly 출력은 renderer="browser" 옵션으로 브라우저 렌더

---

## ✅ 확인 사항 (Checklist)
- [x] 데이터 경로 및 파일 정상 로딩 확인
- [x] Matplotlib 한글 폰트 적용
- [x] Plotly 그래프 브라우저 렌더 정상
- [x] 코드 전 섹션 실행 시 오류 없음

---

## 📌 참고 (Reference)
- 데이터 출처: [Transfermarkt](https://www.transfermarkt.com)
- 강의 자료: 제로베이스 파이썬 데이터 취업 스쿨