### PR TITLE
Add Scrapping Data notebook: 데이터 스크래핑

### DIFF
--- a/notebooks/football_transfer_analysis.ipynb
+++ b/notebooks/football_transfer_analysis.ipynb
@@ -241,9 +241,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "21",
+   "metadata": {},
+   "source": []
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +275,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "source": [
     "# 4. Visaulization"
@@ -278,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "source": [
     "## 4-1. 연도별 선수가치 분포도"
@@ -302,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -317,7 +323,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "대부분의 선수들의 시장가치는 낮은 구간에 몰려있고\n",
@@ -327,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -340,7 +346,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "* x축: market_value_in_eur (시장가치, 보통 유로 단위).\n",
@@ -355,7 +361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,7 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -409,7 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -425,7 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +448,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +458,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -485,7 +491,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "## 4-2. 나이별 시장가치 분포도"
@@ -494,7 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,7 +510,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -548,7 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -589,7 +595,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "## 4-3. 포지셜별 가치 분포"
@@ -598,7 +604,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -616,7 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -640,7 +646,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -670,7 +676,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -704,7 +710,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "## 4-4. 국가별 가치 분포"
@@ -713,7 +719,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -739,7 +745,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -764,7 +770,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "source": [
     "## 4-5. 국가별 선수 수 분포도"
@@ -773,7 +779,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -811,7 +817,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -828,7 +834,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -856,7 +862,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -884,7 +890,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -916,7 +922,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -934,7 +940,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -967,7 +973,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -997,7 +1003,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1025,7 +1031,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "source": [
     "## 4-5. 클럽 단위 총 가치"
@@ -1034,7 +1040,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1052,7 +1058,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1062,7 +1068,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1072,7 +1078,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1085,7 +1091,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1096,7 +1102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1109,7 +1115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1127,7 +1133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1137,7 +1143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1148,7 +1154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1169,7 +1175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1184,7 +1190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1197,7 +1203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1210,7 +1216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1221,12 +1227,386 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "76",
+   "metadata": {},
+   "source": [
+    "## 5. Data Scrapping"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77",
+   "metadata": {},
+   "source": [
+    "## 5-1. 리그/대회 이름 별 그룹핑"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "78",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# 리그(competition_name)별로 클럽들의 total_market_value 합계를 구함\n",
+    "top_5_competition = clubs_2022.groupby('competition_name')['total_market_value'].sum()\n",
+    "\n",
+    "# 합계 기준 내림차순 정렬 후 상위 5개 리그만 추출 → 리그 이름만(Index 형태로) 가져옴\n",
+    "top_5_competition = top_5_competition.sort_values(ascending=False).head(5).index\n",
+    "\n",
+    "# clubs_2022에서 'competition_name'이 상위 5개 리그에 속하는 클럽들만 필터링\n",
+    "# 해당 클럽들의 'club_id'만 뽑아서 unique()로 중복 제거\n",
+    "club_ids = clubs_2022[clubs_2022['competition_name'].isin(top_5_competition)]['club_id'].unique()\n",
+    "\n",
+    "# 결과: 상위 5개 리그에 속하는 클럽들의 고유한 club_id 리스트\n",
+    "club_ids"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79",
+   "metadata": {},
+   "source": [
+    "## 5-2. 상위 5개 리그 소속의 골키퍼 제외한 모든 선수들 포지션,리그명"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 분석에 필요한 컬럼만 선택\n",
+    "columns = ['player_id', 'current_club_id', 'first_name', 'last_name',\n",
+    "           'name', 'position', 'sub_position', 'age', 'market_value_in_eur']\n",
+    "\n",
+    "# 1) 상위 5개 리그(club_ids에 속한 클럽) 선수만 필터링 → 지정된 컬럼만 추출\n",
+    "players_with_stats = players_with_val_2022[players_with_val_2022['current_club_id'].isin(club_ids)][columns]\n",
+    "\n",
+    "# 2) 포지션이 'Goalkeeper'인 선수 제외\n",
+    "players_with_stats = players_with_stats[players_with_stats['position'] != 'Goalkeeper']\n",
+    "\n",
+    "# 3) 클럽 ID → 클럽 이름 매핑 (clubs_2022에서 club_id와 club_name 매칭)\n",
+    "players_with_stats['current_club_name'] = players_with_stats['current_club_id'].map(\n",
+    "    clubs_2022.set_index('club_id')['club_name']\n",
+    ")\n",
+    "\n",
+    "# 4) 클럽 ID → 소속 리그 이름 매핑 (clubs_2022에서 club_id와 competition_name 매칭)\n",
+    "players_with_stats['competition_name'] = players_with_stats['current_club_id'].map(\n",
+    "    clubs_2022.set_index('club_id')['competition_name']\n",
+    ")\n",
+    "\n",
+    "# 5) 시장가치(market_value_in_eur)를 기준으로 내림차순 정렬 (가장 비싼 선수부터 위에 오도록)\n",
+    "players_with_stats = players_with_stats.sort_values(by='market_value_in_eur', ascending=False)\n",
+    "\n",
+    "# 최종 DataFrame: 상위 5개 리그 소속의 골키퍼 제외한 모든 선수들의 스탯 + 클럽/리그 이름\n",
+    "players_with_stats"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "attack_df = players_with_stats[players_with_stats['position'] == 'Attack'].reset_index(drop=True)\n",
+    "display(attack_df.head())\n",
+    "\n",
+    "midfield_df = players_with_stats[players_with_stats['position'] == 'Midfield'].reset_index(drop=True)\n",
+    "display(midfield_df.head())\n",
+    "\n",
+    "defender_df = players_with_stats[players_with_stats['position'] == 'Defender'].reset_index(drop=True)\n",
+    "display(defender_df.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from selenium import webdriver\n",
+    "from selenium.webdriver.common.by import By\n",
+    "\n",
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://1xbet.whoscored.com/Regions/74/Tournaments/22/Seasons/9129/Stages/21037/PlayerStatistics/France-Ligue-1-2022-2023\",\n",
+    "    \"https://1xbet.whoscored.com/Regions/252/Tournaments/2/Seasons/9075/Stages/20934/PlayerStatistics/England-Premier-League-2022-2023\",\n",
+    "    \"https://1xbet.whoscored.com/Regions/81/Tournaments/3/Seasons/9120/Stages/21026/PlayerStatistics/Germany-Bundesliga-2022-2023\",\n",
+    "    \"https://1xbet.whoscored.com/Regions/206/Tournaments/4/Seasons/9149/Stages/21073/PlayerStatistics/Spain-LaLiga-2022-2023\",\n",
+    "    \"https://1xbet.whoscored.com/Regions/108/Tournaments/5/Seasons/9159/Stages/21087/PlayerStatistics/Italy-Serie-A-2022-2023\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "position_df_dict = {\n",
+    "    \"Offensive\": attack_df,\n",
+    "    \"Passing\": midfield_df,\n",
+    "    \"Defensive\": defender_df\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85",
+   "metadata": {},
+   "source": [
+    "크롬 브라우저를 자동으로 켜는 WebDriver 생성하여 urls 페이지들 열어 전체 선수보이는 페이지 띄우기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "driver = webdriver.Chrome()\n",
+    "\n",
+    "url = urls[0]\n",
+    "driver.get(url)\n",
+    "\n",
+    "driver.maximize_window()\n",
+    "\n",
+    "driver.execute_script(\"window.scrollTo(0,700)\")\n",
+    "\n",
+    "apps = driver.find_elements(By.ID, 'apps')[-1]\n",
+    "all_players = apps.find_elements(By.CLASS_NAME, 'option')[-1]\n",
+    "all_players.click()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 크롤링하려는 페이지 -> 전체 페이지 수(totalPages)\n",
+    "total_pages = int(driver.find_elements(By.ID, \"totalPages\")[-1].get_attribute('value'))\n",
+    "total_pages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "html = driver.page_source # 현재 크롬 드라이버(driver)가 띄운 웹페이지의 HTML 원본을 가져옴\n",
+    "soup = BeautifulSoup(html, 'html.parser') # HTML을 다루기 쉽게 객체 구조로 바꿈\n",
+    "table = soup.findAll('table') # 페이지 안에 있는 <table> 태그들을 전부 찾아 리스트로 반환\n",
+    "stats_table = pd.read_html(str(table[1]))[0].iloc[:,1:] # 첫 번째 컬럼을 제외하고 나머지 열만 선택 -> 첫 열은 인덱스/번호라서 버림\n",
+    "stats_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89",
+   "metadata": {},
+   "source": [
+    "## 5-3. 웹에서 긁어온 스탯 테이블을 defender_df 선수 데이터프레임에 매핑"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stats_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# stats_table에서 선수 이름을 추출 → defender_df와 매칭 → 스탯 값 채워 넣기 → 다음 페이지로 이동\n",
+    "player_names = defender_df['name'].unique()\n",
+    "\n",
+    "for idx, row in stats_table.iterrows():\n",
+    "    player_info = row['Player.1'].split(' ')\n",
+    "    player_name = ' '.join(player_info[:2])\n",
+    "    if player_name in player_names:\n",
+    "        print(player_name)\n",
+    "        player_row = defender_df[defender_df['name'] == player_name].iloc[0]\n",
+    "        defender_df.loc[player_row.name, stats_table.columns[1:]] = row[1:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "next_button = driver.find_elements(By.ID, \"next\")\n",
+    "next_button[-1].click()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "driver.quit()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94",
+   "metadata": {},
+   "source": [
+    " 각 URL 팀 페이지를 열고 → 포지션(3개)을 순서대로 클릭 → “All players”로 바꾼 뒤 → 페이지네이션을 돌며 표를 읽어와 → 내 position_df_dict(Attack/Midfield/Defender 등)에 스탯을 채워 넣기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# \tURL 하나당 드라이버를 새로 띄우고 끝에 quit()로 닫아주는 구조\n",
+    "for url in urls:\n",
+    "    driver = webdriver.Chrome()\n",
+    "\n",
+    "    driver.get(url)\n",
+    "\n",
+    "    driver.maximize_window()\n",
+    "\n",
+    "    driver.execute_script(\"window.scrollTo(0,700)\")\n",
+    "# 상세 스쿼드 보기” 버튼들 중 마지막 하나는 제외하고 0,1,2(=3개 포지션)을 순회 클릭 후 1.5초 하드 슬립으로 로딩 대기\n",
+    "    for i in range(3):\n",
+    "        positions = driver.find_elements(By.CLASS_NAME, \"in-squad-detailed-view\")[:-1]\n",
+    "        position = positions[i]\n",
+    "        position.click()\n",
+    "        time.sleep(1.5)\n",
+    "\n",
+    "        key = position.text.strip()\n",
+    "        df = position_df_dict[key]\n",
+    "        player_names = df['name'].unique()\n",
+    "\n",
+    "        # id=apps(드롭다운)에서 마지막 옵션(보통 “All players”) 클릭 → 전체 선수 보기로 전환.\n",
+    "        apps = driver.find_elements(By.ID, 'apps')[-1]\n",
+    "        all_players = apps.find_elements(By.CLASS_NAME, 'option')[-1]\n",
+    "        all_players.click()\n",
+    "        time.sleep(1.5)\n",
+    "\n",
+    "        # 전체 페이지 수(totalPages)만큼 루프.\n",
+    "        total_pages = int(driver.find_elements(By.ID, \"totalPages\")[-1].get_attribute('value'))\n",
+    "        for _ in range(total_pages):\n",
+    "            html = driver.page_source\n",
+    "            soup = BeautifulSoup(html, 'html.parser')\n",
+    "\n",
+    "            tables = soup.findAll('table')[:-1]\n",
+    "            table = str(tables[-1])\n",
+    "            stats_table = pd.read_html(table)[0].iloc[:,1:]\n",
+    "\n",
+    "            for idx, row in stats_table.iterrows():\n",
+    "                player_info = row['Player.1'].split(' ')\n",
+    "                player_name = ' '.join(player_info[:2])\n",
+    "\n",
+    "                if player_name in player_names:\n",
+    "                    player_row = df[df['name'] == player_name].iloc[0]\n",
+    "                    df.loc[player_row.name, stats_table.columns[1:]] = row[1:]\n",
+    "\n",
+    "            next_button = driver.find_elements(By.ID, \"next\")\n",
+    "            next_button[-1].click()\n",
+    "            time.sleep(1.5)\n",
+    "\n",
+    "    driver.quit()\n",
+    "    time.sleep(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "attack_df_with_stats = position_df_dict['Offensive']\n",
+    "midfield_df_with_stats = position_df_dict['Passing']\n",
+    "defender_df_with_stats = position_df_dict['Defensive']\n",
+    "\n",
+    "display(attack_df_with_stats)\n",
+    "display(midfield_df_with_stats)\n",
+    "display(defender_df_with_stats)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "attack_df_with_stats_isna = attack_df_with_stats.isna().sum() / len(attack_df_with_stats) * 100\n",
+    "midfield_df_with_stats_isna = midfield_df_with_stats.isna().sum() / len(midfield_df_with_stats) * 100\n",
+    "defender_df_with_stats_isna = defender_df_with_stats.isna().sum() / len(defender_df_with_stats) * 100\n",
+    "\n",
+    "print(\"Attack DataFrame NaN Ratio:\")\n",
+    "print(attack_df_with_stats_isna)\n",
+    "\n",
+    "print(\"\\nMidfield DataFrame NaN Ratio:\")\n",
+    "print(midfield_df_with_stats_isna)\n",
+    "\n",
+    "print(\"\\nDefender DataFrame NaN Ratio:\")\n",
+    "print(defender_df_with_stats_isna)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "attack_df_with_stats.dropna(inplace=True)\n",
+    "midfield_df_with_stats.dropna(inplace=True)\n",
+    "defender_df_with_stats.dropna(inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(attack_df_with_stats\n",
+    "display(midfield_df_with_stats)\n",
+    "display(defender_df_with_stats)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## 📊 작업 내용 (What)
* 스크래핑 결과를 공격·미드필더·수비수 세 구분으로 CSV 로딩
* 포지션별 데이터프레임 기본 구조 확인을 위해 head() 출력
---

## 🛠️ 변경 사항 (Changes)
*  attack_df, midfield_df, defender_df CSV 로딩 셀 추가
* 각 데이터프레임 상위 5행을 브라우저에서 시각 확인하도록 `display()` 호출 구성
---

## ✅ 확인 사항 (Checklist)
 - [x] 세 CSV 경로 정상 지정 및 로딩 성공
 - [x] DataFrame head() 호출 시 포맷·열 구조 확인 완료

---

## 📌 참고 (Reference)
- 데이터 출처: [Transfermarkt](https://www.transfermarkt.com)
- 강의 자료: 제로베이스 파이썬 데이터 취업 스쿨